### PR TITLE
Update README.mkdn

### DIFF
--- a/profile/README.mkdn
+++ b/profile/README.mkdn
@@ -22,5 +22,5 @@ Here are some points to note while applying the official maintainership :-
 
 ### Reach US
 
-- [Telegram Announcements/Device Updates](https://https://t.me/ProjectInfinityX)
-- [Telegram Discussion Group](https://https://t.me/InfinityXGroup)
+- [Telegram Announcements/Device Updates](https://t.me/ProjectInfinityX)
+- [Telegram Discussion Group](https://t.me/InfinityXGroup)


### PR DESCRIPTION
This pull request fixes the incorrect links to Telegram groups in the README file.
Corrected the URLs by removing the duplicate " https:// " from the links.